### PR TITLE
fix value = 40 bug and add tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 var lookup = require('./lookup');
 module.exports = function(srm) {
-  if (srm < 0.1) return '#FFFFFF';
-  if (srm > 40) return '#000000';
+  if (srm <= 0) return '#FFFFFF';
+  if (srm >= 40) return '#000000';
   var rgb = lookup[Math.floor(srm * 10)];
   return '#' + rgb[0].toString(16) + rgb[1].toString(16) + rgb[2].toString(16);
 };

--- a/package.json
+++ b/package.json
@@ -1,9 +1,13 @@
 {
   "name": "srm2hex",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Convert SRM colours to their hex value equivalents.",
   "main": "index.js",
+  "scripts": { "test": "jasmine" },
   "repository": "http://www.github.com/jonpacker/srm2hex",
   "author": "Jon Packer",
-  "license": "MIT"
+  "license": "MIT",
+  "devDependencies": {
+    "jasmine": "^2.8.0"
+  }
 }

--- a/spec/srm2hexSpec.js
+++ b/spec/srm2hexSpec.js
@@ -1,0 +1,15 @@
+var srm2hex = require("../index");
+
+describe("basic functionality", () => {
+  it("exports a valid hex", () => {
+    expect(srm2hex(20.5)).toEqual('#562e11');
+  });
+  it("returns white for srm values at 0 or below", () => {
+      expect(srm2hex(0)).toEqual('#FFFFFF');
+      expect(srm2hex(-1)).toEqual('#FFFFFF');
+  });
+  it("returns black for srm values at 0 or below", () => {
+      expect(srm2hex(40)).toEqual('#000000');
+      expect(srm2hex(41)).toEqual('#000000');
+  });
+});

--- a/spec/support/jasmine.json
+++ b/spec/support/jasmine.json
@@ -1,0 +1,11 @@
+{
+  "spec_dir": "spec",
+  "spec_files": [
+    "**/*[sS]pec.js"
+  ],
+  "helpers": [
+    "helpers/**/*.js"
+  ],
+  "stopSpecOnExpectationFailure": false,
+  "random": false
+}


### PR DESCRIPTION
Hi! Thanks for putting this handy little library together. It helped me out on an update to https://beergoggl.es. 

I found a bug where SRM values of exactly 40 returned:
```
  return '#' + rgb[0].toString(16) + rgb[1].toString(16) + rgb[2].toString(16);
                  ^

TypeError: Cannot read property '0' of undefined
```

The issue was just a greater=than-or-equals. I made a quick patch here and added a few tests, in case you're interested. I know this is a pretty old piece of code.

Cheers! 🍻